### PR TITLE
Workaround git describe error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN apk add --no-cache \
     reno==3.1.0
 
 ARG DATADOG_VERSION=7.24.1
-RUN git clone -b ${DATADOG_VERSION} --depth=1 https://github.com/DataDog/datadog-agent.git /build/datadog-agent
+RUN git clone -b ${DATADOG_VERSION} https://github.com/DataDog/datadog-agent.git /build/datadog-agent
 
 WORKDIR /build/datadog-agent
 


### PR DESCRIPTION
Now, the builds fail with
```
Step 24/60 : RUN invoke agent.build     --python-runtimes=3     --exclude-rtloader     --build-exclude=jmx,kubeapiserver,gce,ec2
 ---> Running in a77eaa73a30d
Encountered a bad command exit code!

Command: 'git describe --tags --candidates=50 --match "7\\.*" --abbrev=7'

Exit code: 128

Stdout:



Stderr:

fatal: No names found, cannot describe anything.

The command '/bin/sh -c invoke agent.build     --python-runtimes=3     --exclude-rtloader     --build-exclude=jmx,kubeapiserver,gce,ec2' returned a non-zero code: 128
Makefile:31: recipe for target 'docker-build' failed
make: *** [docker-build] Error 128
Error: Process completed with exit code 2.
```
related upstream code: https://github.com/DataDog/datadog-agent/blob/94688546f3b6ed500d790bfec13cc9812a22d3f3/tasks/utils.py#L216-L219