### PR TITLE
Reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -290,6 +290,7 @@ RUN apk add --force-broken-world --virtual .build-deps \
   && git fetch --depth=1 origin refs/tags/${DATADOG_INTEGRATIONS_CORE_VERSION}:refs/tags/${DATADOG_INTEGRATIONS_CORE_VERSION} \
   && git checkout refs/tags/${DATADOG_INTEGRATIONS_CORE_VERSION} \
   && for d in \
+      botocore \
       cryptography \
       prometheus-client \
       protobuf \
@@ -307,7 +308,13 @@ RUN apk add --force-broken-world --virtual .build-deps \
   && cd / && rm -rf /tmp/integrations-core \
   && rm -f /var/cache/apk/* \
   && find /usr -name "*.pyc" -delete \
-  && find /usr -name "__pycache__" -delete
+  && find /usr -name "__pycache__" -delete \
+  && rm -rf \
+    /usr/lib/python*/site-packages/twisted/test
+
+# note: removed packages from datadog_checks_base/requirements.in
+#   botocore: seems not used at all https://github.com/DataDog/integrations-core/search?q=botocore
+#   other packages: installed as Alpine package
 
 EXPOSE 8125/udp 8126/tcp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -310,11 +310,16 @@ RUN apk add --force-broken-world --virtual .build-deps \
   && find /usr -name "*.pyc" -delete \
   && find /usr -name "__pycache__" -delete \
   && rm -rf \
-    /usr/lib/python*/site-packages/twisted/test
+    /usr/lib/python*/site-packages/twisted/test \
+    /usr/lib/python*/site-packages/docutils
 
 # note: removed packages from datadog_checks_base/requirements.in
 #   botocore: seems not used at all https://github.com/DataDog/integrations-core/search?q=botocore
 #   other packages: installed as Alpine package
+
+# note: removed directories
+#   twisted/test: unit test of twisted package
+#   docutils: indirect dev dependency
 
 EXPOSE 8125/udp 8126/tcp
 


### PR DESCRIPTION
Remove
- botocore (seems not used at all https://github.com/DataDog/integrations-core/search?q=botocore) 42MB
- twisted/test (unit test files) 2MB
- docutils (indirect dev dependency) 2MB