### PR TITLE
Fix symlink to libsystemd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,12 @@ RUN ./configure \
     -Didn=false \
     -Dutmp=false
 RUN ninja -C build libsystemd.so.${SYSTEMD_LIB_VERSION}
-RUN cp -v $(find build -name "libsystemd.so*" -type f) /usr/local/lib/
+RUN cp -v $(find build -name "libsystemd.so.${SYSTEMD_LIB_VERSION}" -type f) /usr/local/lib/
+RUN strip -s /usr/local/lib/libsystemd.so.${SYSTEMD_LIB_VERSION}
 
-RUN strip -s /usr/local/lib/libsystemd.so*
+RUN cd /usr/local/lib/ \
+  && ln -s libsystemd.so.${SYSTEMD_LIB_VERSION} libsystemd.so.0 \
+  && ln -s libsystemd.so.${SYSTEMD_LIB_VERSION} libsystemd.so
 
 
 # ===========================


### PR DESCRIPTION
Systemd/journald integration on 7.26.0 to 7.28.1 image doesn't work due to missing symlink to libsystemd.

It can be worked around by adding
```
RUN ln -s /usr/lib/libsystemd.so.0.29.0 /usr/lib/libsystemd.so.0
```
to these images.