### PR TITLE
Set base image major version of integrations-builder by arg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ docker-build-integrations-builder:
 ifeq ($(ENABLE_PROCESS_AGENT)$(ENABLE_SECURITY_AGENT)$(ENABLE_TRACE_AGENT)$(ENABLE_SYSTEM_PROBE),0000)
 	docker build \
 		$(BUILD_OPTS) \
+		--build-arg DATADOG_MAJOR_VERSION=$(DATADOG_MAJOR_VERSION) \
 		-f integrations-builder.Dockerfile \
 		-t $(NAME):$(TAG)-integrations-builder .
 	@echo $(NAME):$(TAG)-integrations-builder is built

--- a/integrations-builder.Dockerfile
+++ b/integrations-builder.Dockerfile
@@ -1,4 +1,5 @@
-FROM datadog-agent:7-alpine
+ARG DATADOG_MAJOR_VERSION
+FROM datadog-agent:${DATADOG_MAJOR_VERSION}-alpine
 
 WORKDIR /wheels
 


### PR DESCRIPTION
Workaround renovate external-host-error