### PR TITLE
Bump golang image Alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN strip -s /usr/local/lib/libsystemd.so.${SYSTEMD_LIB_VERSION}
 
 
 # ===========================
-FROM golang:1.17-alpine3.14 AS agent-builder
+FROM golang:1.17-alpine3.16 AS agent-builder
 
 RUN apk add --no-cache \
     aws-cli \

--- a/Dockerfile
+++ b/Dockerfile
@@ -162,6 +162,7 @@ RUN if [ ${ENABLE_SYSTEM_PROBE} -eq 1 ]; then \
     for l in /usr/lib/llvm${LLVM_VERSION}/lib/*.a; do \
       ln -s $l /usr/lib/; \
     done; \
+    patch -p1 < ebpf-llvm12.patch; \
     invoke system-probe.build \
       --python-runtimes=3; \
     mv bin/system-probe/system-probe /agent-bin/; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -143,6 +143,8 @@ RUN if [ ${ENABLE_TRACE_AGENT} -eq 1 ]; then \
     mv bin/trace-agent/trace-agent /agent-bin/; \
   fi
 
+COPY ebpf-llvm12.patch ./
+
 ARG ENABLE_SYSTEM_PROBE=0
 RUN if [ ${ENABLE_SYSTEM_PROBE} -eq 1 ]; then \
     apk add --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -153,12 +153,13 @@ RUN if [ ${ENABLE_SYSTEM_PROBE} -eq 1 ]; then \
       linux-virt-dev \
       linux-headers \
       libbpf-dev \
-      llvm11 \
-      llvm11-dev \
-      llvm11-static; \
-    ln -s /usr/include/llvm11/llvm /usr/include/; \
-    ln -s /usr/include/llvm11/llvm-c /usr/include/; \
-    for l in /usr/lib/llvm11/lib/*.a; do \
+      llvm \
+      llvm-dev \
+      llvm-static; \
+    LLVM_VERSION=$(apk info -e llvm | sed 's/^llvm//'); \
+    ln -s /usr/include/llvm${LLVM_VERSION}/llvm /usr/include/; \
+    ln -s /usr/include/llvm${LLVM_VERSION}/llvm-c /usr/include/; \
+    for l in /usr/lib/llvm${LLVM_VERSION}/lib/*.a; do \
       ln -s $l /usr/lib/; \
     done; \
     invoke system-probe.build \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16 as systemd-builder
+FROM alpine:3.15 as systemd-builder
 
 RUN apk add --no-cache \
     autoconf \
@@ -50,7 +50,7 @@ RUN strip -s /usr/local/lib/libsystemd.so.${SYSTEMD_LIB_VERSION}
 
 
 # ===========================
-FROM golang:1.17-alpine3.16 AS agent-builder
+FROM golang:1.17-alpine3.15 AS agent-builder
 
 RUN apk add --no-cache \
     aws-cli \
@@ -202,7 +202,7 @@ RUN rm -rf \
 
 
 # ===========================
-FROM alpine:3.16 AS datadog-agent
+FROM alpine:3.15 AS datadog-agent
 
 ARG ENABLE_SYSTEM_PROBE=1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15 as systemd-builder
+FROM alpine:3.16 as systemd-builder
 
 RUN apk add --no-cache \
     autoconf \
@@ -50,7 +50,7 @@ RUN strip -s /usr/local/lib/libsystemd.so.${SYSTEMD_LIB_VERSION}
 
 
 # ===========================
-FROM golang:1.17-alpine3.15 AS agent-builder
+FROM golang:1.17-alpine3.16 AS agent-builder
 
 RUN apk add --no-cache \
     aws-cli \
@@ -203,7 +203,7 @@ RUN rm -rf \
 
 
 # ===========================
-FROM alpine:3.15 AS datadog-agent
+FROM alpine:3.16 AS datadog-agent
 
 ARG ENABLE_SYSTEM_PROBE=1
 

--- a/ebpf-llvm12.patch
+++ b/ebpf-llvm12.patch
@@ -10,3 +10,16 @@ index bf70e907f..3f8b9ceaf 100644
          llvm::vfs::getRealFileSystem()
      );
  
+diff --git a/pkg/ebpf/compiler/compiler.go b/pkg/ebpf/compiler/compiler.go
+index 652ff332f..211a87465 100644
+--- a/pkg/ebpf/compiler/compiler.go
++++ b/pkg/ebpf/compiler/compiler.go
+@@ -11,7 +11,7 @@ package compiler
+ /*
+ #cgo LDFLAGS: -lclangCodeGen -lclangFrontend -lclangSerialization -lclangDriver -lclangParse -lclangSema -lclangAnalysis -lclangASTMatchers -lclangRewrite -lclangEdit -lclangAST -lclangLex -lclangBasic
+ #cgo LDFLAGS: -L/opt/datadog-agent/embedded/lib
+-#cgo LDFLAGS: -lLLVMXRay -lLLVMWindowsManifest -lLLVMTableGen -lLLVMSymbolize -lLLVMDebugInfoPDB -lLLVMOrcJIT -lLLVMOrcError -lLLVMJITLink -lLLVMObjectYAML -lLLVMMIRParser -lLLVMMCJIT -lLLVMMCA -lLLVMLTO -lLLVMPasses -lLLVMCoroutines -lLLVMObjCARCOpts -lLLVMipo -lLLVMInstrumentation -lLLVMVectorize -lLLVMLinker -lLLVMIRReader -lLLVMAsmParser -lLLVMFrontendOpenMP -lLLVMExtensions -lLLVMLineEditor -lLLVMLibDriver -lLLVMGlobalISel -lLLVMFuzzMutate -lLLVMInterpreter -lLLVMExecutionEngine -lLLVMRuntimeDyld -lLLVMDWARFLinker -lLLVMDlltoolDriver -lLLVMOption -lLLVMDebugInfoGSYM -lLLVMCoverage -lLLVMCFGuard -lLLVMBPFDisassembler -lLLVMMCDisassembler -lLLVMBPFCodeGen -lLLVMSelectionDAG -lLLVMAsmPrinter -lLLVMDebugInfoDWARF -lLLVMCodeGen -lLLVMTarget -lLLVMScalarOpts -lLLVMInstCombine -lLLVMAggressiveInstCombine -lLLVMTransformUtils -lLLVMBitWriter -lLLVMAnalysis -lLLVMProfileData -lLLVMObject -lLLVMTextAPI -lLLVMBitReader -lLLVMCore -lLLVMRemarks -lLLVMBitstreamReader -lLLVMBPFAsmParser -lLLVMMCParser -lLLVMBPFDesc -lLLVMMC -lLLVMDebugInfoCodeView -lLLVMDebugInfoMSF -lLLVMBinaryFormat -lLLVMBPFInfo -lLLVMSupport -lLLVMDemangle
++#cgo LDFLAGS: -lLLVMXRay -lLLVMWindowsManifest -lLLVMTableGen -lLLVMSymbolize -lLLVMDebugInfoPDB -lLLVMOrcJIT -lLLVMJITLink -lLLVMObjectYAML -lLLVMMIRParser -lLLVMMCJIT -lLLVMMCA -lLLVMLTO -lLLVMPasses -lLLVMCoroutines -lLLVMObjCARCOpts -lLLVMipo -lLLVMInstrumentation -lLLVMVectorize -lLLVMLinker -lLLVMIRReader -lLLVMAsmParser -lLLVMFrontendOpenMP -lLLVMExtensions -lLLVMLineEditor -lLLVMLibDriver -lLLVMGlobalISel -lLLVMFuzzMutate -lLLVMInterpreter -lLLVMExecutionEngine -lLLVMRuntimeDyld -lLLVMDWARFLinker -lLLVMDlltoolDriver -lLLVMOption -lLLVMDebugInfoGSYM -lLLVMCoverage -lLLVMCFGuard -lLLVMBPFDisassembler -lLLVMMCDisassembler -lLLVMBPFCodeGen -lLLVMSelectionDAG -lLLVMAsmPrinter -lLLVMDebugInfoDWARF -lLLVMCodeGen -lLLVMTarget -lLLVMScalarOpts -lLLVMInstCombine -lLLVMAggressiveInstCombine -lLLVMTransformUtils -lLLVMBitWriter -lLLVMAnalysis -lLLVMProfileData -lLLVMObject -lLLVMTextAPI -lLLVMBitReader -lLLVMCore -lLLVMRemarks -lLLVMBitstreamReader -lLLVMBPFAsmParser -lLLVMMCParser -lLLVMBPFDesc -lLLVMMC -lLLVMDebugInfoCodeView -lLLVMDebugInfoMSF -lLLVMBinaryFormat -lLLVMBPFInfo -lLLVMSupport -lLLVMDemangle
+ #cgo LDFLAGS: -lz -ldl -lm -lrt -static-libstdc++ -lpthread
+ #cgo LDFLAGS: -Wl,--wrap=exp -Wl,--wrap=log -Wl,--wrap=pow -Wl,--wrap=log2 -Wl,--wrap=log2f
+ #cgo CXXFLAGS: -I/opt/datadog-agent/embedded/include -std=c++14 -fno-exceptions -fno-rtti -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DLLVM_MAJOR_VERSION=11

--- a/ebpf-llvm12.patch
+++ b/ebpf-llvm12.patch
@@ -1,0 +1,12 @@
+diff --git a/pkg/ebpf/compiler/compiler.cpp b/pkg/ebpf/compiler/compiler.cpp
+index bf70e907f..3f8b9ceaf 100644
+--- a/pkg/ebpf/compiler/compiler.cpp
++++ b/pkg/ebpf/compiler/compiler.cpp
+@@ -52,6 +52,7 @@ ClangCompiler::ClangCompiler(const char *name) :
+ 
+     theDriver = std::make_unique<clang::driver::Driver>(
+         name, getArch(), *diagnosticsEngine,
++        "clang LLVM compiler",
+         llvm::vfs::getRealFileSystem()
+     );
+ 


### PR DESCRIPTION
Add patch for llvm>=12 (Alpine 3.16 default is llvm 13)