### PR TITLE
Use py3-packaging from alpine repo

### DIFF
--- a/integrations-builder.Dockerfile
+++ b/integrations-builder.Dockerfile
@@ -18,6 +18,7 @@ RUN apk add --no-cache \
     py3-bcrypt \
     py3-cryptography \
     py3-distlib \
+    py3-packaging \
     py3-pynacl \
     py3-pip \
     py3-regex \
@@ -40,6 +41,7 @@ RUN git clone --depth=1 https://github.com/DataDog/integrations-core.git /tmp/in
     bcrypt==$(version py3-bcrypt) \
     cryptography==$(version py3-cryptography) \
     distlib==$(version py3-distlib) \
+    packaging==$(version py3-packaging) \
     pynacl==$(version py3-pynacl) \
     pip==$(version py3-pip) \
     regex==$(version py3-regex) \


### PR DESCRIPTION
https://github.com/seqsense/datadog-agent-alpine/actions/runs/4071902458/jobs/7014137803#step:11:716
```
#10 153.5   Attempting uninstall: packaging
#10 153.6     Found existing installation: packaging 21.3
#10 153.6 ERROR: Cannot uninstall 'packaging'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.
```