### PR TITLE
Install ddev from corresponding version of integrations-core

### DIFF
--- a/integrations-builder.Dockerfile
+++ b/integrations-builder.Dockerfile
@@ -44,7 +44,7 @@ RUN git clone --depth=1 https://github.com/DataDog/integrations-core.git /tmp/in
     pip==$(version py3-pip) \
     regex==$(version py3-regex) \
     "/tmp/integrations-core/datadog_checks_dev[cli]" \
-    ddev \
+    "/tmp/integrations-core/ddev" \
   && rm -rf /tmp/integrations-core
 
 CMD ["/bin/sh"]


### PR DESCRIPTION
`ddev` was installed from pypi.
Fix compatibility of `ddev` and `datadog_checks_dev`.