### PR TITLE
Separate Renovate minor updates of Alpine and Golang

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -85,6 +85,13 @@
       "matchPackageNames": [
         "/^DataDog/*/"
       ]
+    },
+    {
+      "matchPackageNames": [
+        "/^alpine$/",
+        "/^golang$/"
+      ],
+      "separateMultipleMinor": true
     }
   ]
 }


### PR DESCRIPTION
Latest version is usually unsupported and need to update to the previous one